### PR TITLE
Bootstrap RDS DB and S3 buckets for terraform state

### DIFF
--- a/root/bootstrap/main.tf
+++ b/root/bootstrap/main.tf
@@ -1,0 +1,7 @@
+module "bootstrap" {
+  source = "trussworks/bootstrap/aws"
+  version = "0.1.4"
+
+  region        = "us-west-2"
+  account_alias = "benching-security-truss-test"
+}

--- a/root/bootstrap/providers.tf
+++ b/root/bootstrap/providers.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  version = "~> 2.70.0"
+  region  = "us-west-2"
+}


### PR DESCRIPTION
Plan (in case it doesn't show up in spacelift)

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.bootstrap.aws_dynamodb_table.terraform_state_lock will be created
  + resource "aws_dynamodb_table" "terraform_state_lock" {
      + arn              = (known after apply)
      + billing_mode     = "PROVISIONED"
      + hash_key         = "LockID"
      + id               = (known after apply)
      + name             = "terraform-state-lock"
      + read_capacity    = 2
      + stream_arn       = (known after apply)
      + stream_label     = (known after apply)
      + stream_view_type = (known after apply)
      + tags             = {
          + "Automation" = "Terraform"
          + "Name"       = "terraform-state-lock"
        }
      + write_capacity   = 2

      + attribute {
          + name = "LockID"
          + type = "S"
        }

      + point_in_time_recovery {
          + enabled = (known after apply)
        }

      + server_side_encryption {
          + enabled     = true
          + kms_key_arn = (known after apply)
        }
    }

  # module.bootstrap.aws_iam_account_alias.alias will be created
  + resource "aws_iam_account_alias" "alias" {
      + account_alias = "benching-security-truss-test"
      + id            = (known after apply)
    }

  # module.bootstrap.module.terraform_state_bucket.aws_s3_bucket.private_bucket will be created
  + resource "aws_s3_bucket" "private_bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = "benching-security-truss-test-tf-state-us-west-2"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + policy                      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "s3:*"
                      + Condition = {
                          + Bool = {
                              + aws:SecureTransport = "false"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-us-west-2/*"
                      + Sid       = "enforce-tls-requests-only"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + ArnLike      = {
                              + aws:SourceArn = "arn:aws:s3:::benching-security-truss-test-tf-state-us-west-2"
                            }
                          + StringEquals = {
                              + aws:SourceAccount = "192140755079"
                              + s3:x-amz-acl      = "bucket-owner-full-control"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "s3.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-us-west-2/*"
                      + Sid       = "inventory-and-analytics"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = {
          + "Automation" = "Terraform"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = 14
          + enabled                                = true
          + id                                     = (known after apply)

          + expiration {
              + expired_object_delete_marker = true
            }

          + noncurrent_version_expiration {
              + days = 365
            }

          + noncurrent_version_transition {
              + days          = 30
              + storage_class = "STANDARD_IA"
            }
        }
      + lifecycle_rule {
          + enabled = true
          + id      = (known after apply)
          + prefix  = "_AWSBucketInventory/"

          + expiration {
              + days = 14
            }
        }
      + lifecycle_rule {
          + enabled = true
          + id      = (known after apply)
          + prefix  = "_AWSBucketAnalytics/"

          + expiration {
              + days = 30
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + server_side_encryption_configuration {
          + rule {
              + apply_server_side_encryption_by_default {
                  + sse_algorithm = "AES256"
                }
            }
        }

      + versioning {
          + enabled    = true
          + mfa_delete = false
        }
    }

  # module.bootstrap.module.terraform_state_bucket.aws_s3_bucket_analytics_configuration.private_analytics_config[0] will be created
  + resource "aws_s3_bucket_analytics_configuration" "private_analytics_config" {
      + bucket = "benching-security-truss-test-tf-state-us-west-2"
      + id     = (known after apply)
      + name   = "Analytics"

      + storage_class_analysis {
          + data_export {
              + output_schema_version = "V_1"

              + destination {
                  + s3_bucket_destination {
                      + bucket_arn = (known after apply)
                      + format     = "CSV"
                      + prefix     = "/_AWSBucketAnalytics"
                    }
                }
            }
        }
    }

  # module.bootstrap.module.terraform_state_bucket.aws_s3_bucket_public_access_block.public_access_block will be created
  + resource "aws_s3_bucket_public_access_block" "public_access_block" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

  # module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs will be created
  + resource "aws_s3_bucket" "aws_logs" {
      + acceleration_status         = (known after apply)
      + acl                         = "log-delivery-write"
      + arn                         = (known after apply)
      + bucket                      = "benching-security-truss-test-tf-state-log-us-west-2"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + policy                      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "s3:GetBucketAcl"
                      + Effect    = "Deny"
                      + Principal = {
                          + Service = "cloudtrail.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2"
                      + Sid       = "cloudtrail-logs-get-bucket-acl"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringEquals = {
                              + s3:x-amz-acl = "bucket-owner-full-control"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + Service = "cloudtrail.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2/cloudtrail/AWSLogs/192140755079/*"
                      + Sid       = "cloudtrail-logs-put-object"
                    },
                  + {
                      + Action    = "s3:GetBucketAcl"
                      + Effect    = "Deny"
                      + Principal = {
                          + Service = "logs.us-west-2.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2"
                      + Sid       = "cloudwatch-logs-get-bucket-acl"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringEquals = {
                              + s3:x-amz-acl = "bucket-owner-full-control"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + Service = "logs.us-west-2.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2/cloudwatch/*"
                      + Sid       = "cloudwatch-logs-put-object"
                    },
                  + {
                      + Action    = "s3:GetBucketAcl"
                      + Effect    = "Deny"
                      + Principal = {
                          + Service = "config.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2"
                      + Sid       = "config-permissions-check"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringEquals = {
                              + s3:x-amz-acl = "bucket-owner-full-control"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + Service = "config.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2/config/AWSLogs/192140755079/Config/*"
                      + Sid       = "config-bucket-delivery"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "arn:aws:iam::797873946194:root"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2/elb/AWSLogs/192140755079/*"
                      + Sid       = "elb-logs-put-object"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "arn:aws:iam::797873946194:root"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2/alb/AWSLogs/192140755079/*"
                      + Sid       = "alb-logs-put-object"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringEquals = {
                              + s3:x-amz-acl = "bucket-owner-full-control"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + Service = "delivery.logs.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2/nlb/AWSLogs/192140755079/*"
                      + Sid       = "nlb-logs-put-object"
                    },
                  + {
                      + Action    = "s3:GetBucketAcl"
                      + Effect    = "Deny"
                      + Principal = {
                          + Service = "delivery.logs.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2"
                      + Sid       = "nlb-logs-acl-check"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "arn:aws:iam::902366379725:user/logs"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2/redshift/*"
                      + Sid       = "redshift-logs-put-object"
                    },
                  + {
                      + Action    = "s3:GetBucketAcl"
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "arn:aws:iam::902366379725:user/logs"
                        }
                      + Resource  = "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2"
                      + Sid       = "redshift-logs-get-bucket-acl"
                    },
                  + {
                      + Action    = "s3:*"
                      + Condition = {
                          + Bool = {
                              + aws:SecureTransport = "false"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = [
                          + "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2/*",
                          + "arn:aws:s3:::benching-security-truss-test-tf-state-log-us-west-2",
                        ]
                      + Sid       = "enforce-tls-requests-only"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + region                      = "us-west-2"
      + request_payer               = (known after apply)
      + tags                        = {
          + "Automation" = "Terraform"
          + "Name"       = "benching-security-truss-test-tf-state-log-us-west-2"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + lifecycle_rule {
          + enabled = true
          + id      = "expire_all_logs"
          + prefix  = "/*"

          + expiration {
              + days = 90
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + apply_server_side_encryption_by_default {
                  + sse_algorithm = "AES256"
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }
    }

  # module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_public_access_block.public_access_block[0] will be created
  + resource "aws_s3_bucket_public_access_block" "public_access_block" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }
 ```